### PR TITLE
FEAT: Add Contentful dynamic navigation changes.

### DIFF
--- a/src/SFA.DAS.TeachInFurtherEducation.Contentful/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SFA.DAS.TeachInFurtherEducation.Contentful/Extensions/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using SFA.DAS.TeachInFurtherEducation.Contentful.Model.Interim;
 using SFA.DAS.TeachInFurtherEducation.Contentful.Services;
 using SFA.DAS.TeachInFurtherEducation.Contentful.Services.Interfaces;
 using SFA.DAS.TeachInFurtherEducation.Contentful.Services.Interfaces.Roots;
+using SFA.DAS.TeachInFurtherEducation.Contentful.Services.Navigation;
 using SFA.DAS.TeachInFurtherEducation.Contentful.Services.Roots;
 
 namespace SFA.DAS.TeachInFurtherEducation.Contentful.Extensions
@@ -27,6 +28,8 @@ namespace SFA.DAS.TeachInFurtherEducation.Contentful.Extensions
                 .AddTransient(sp => ContentService.CreateHtmlRenderer())
                 .AddSingleton<IContentService, ContentService>()
                 .AddSingleton<IPageService, PageService>()
+                .AddSingleton<INavigationTreeBuilder, NavigationTreeBuilder>()
+                .AddScoped<IContentfulNavigationService, ContentfulNavigationService>()
                 .AddTransient<IContentfulClient>(sp =>
                 {
                     var configOptions = sp.GetService<IOptions<ContentfulOptions>>()?.Value;

--- a/src/SFA.DAS.TeachInFurtherEducation.Contentful/Model/Api/Navigation/NavigationMenuTree.cs
+++ b/src/SFA.DAS.TeachInFurtherEducation.Contentful/Model/Api/Navigation/NavigationMenuTree.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SFA.DAS.TeachInFurtherEducation.Web.Models
+{
+    [ExcludeFromCodeCoverage]
+    public sealed class NavigationMenuTree
+    {
+        public string MenuTitle { get; init; } = string.Empty;
+        public IReadOnlyList<NavigationMenuTreeItem> Items { get; init; } = Array.Empty<NavigationMenuTreeItem>();
+    }
+}

--- a/src/SFA.DAS.TeachInFurtherEducation.Contentful/Model/Api/Navigation/NavigationMenuTreeItem.cs
+++ b/src/SFA.DAS.TeachInFurtherEducation.Contentful/Model/Api/Navigation/NavigationMenuTreeItem.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SFA.DAS.TeachInFurtherEducation.Web.Models
+{
+    [ExcludeFromCodeCoverage]
+    public sealed class NavigationMenuTreeItem
+    {
+        public string Id { get; init; } = string.Empty;
+        public string Title { get; init; } = string.Empty;
+        public string Url { get; init; } = string.Empty;
+        public bool OpenInNewTab { get; init; }
+        public bool Enabled { get; init; }
+        public int SortOrder { get; init; }
+        public List<NavigationMenuTreeItem> Children { get; init; } = new();
+    }
+}

--- a/src/SFA.DAS.TeachInFurtherEducation.Contentful/Model/Content/Navigation/NavigationMenu.cs
+++ b/src/SFA.DAS.TeachInFurtherEducation.Contentful/Model/Content/Navigation/NavigationMenu.cs
@@ -1,0 +1,18 @@
+﻿using Contentful.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.TeachInFurtherEducation.Contentful.Model.Content.Navigation
+{
+    [ExcludeFromCodeCoverage]
+    public class NavigationMenu
+    {
+        public SystemProperties Sys { get; set; } = default!;
+        public string Title { get; set; } = string.Empty;
+        public List<NavigationMenuItem> MenuItems { get; set; } = new();
+    }
+}

--- a/src/SFA.DAS.TeachInFurtherEducation.Contentful/Model/Content/Navigation/NavigationMenuItem.cs
+++ b/src/SFA.DAS.TeachInFurtherEducation.Contentful/Model/Content/Navigation/NavigationMenuItem.cs
@@ -1,0 +1,23 @@
+﻿using Contentful.Core.Models;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.TeachInFurtherEducation.Contentful.Model.Content.Navigation
+{
+    [ExcludeFromCodeCoverage]
+    public class NavigationMenuItem
+    {
+        public SystemProperties Sys { get; set; } = default!;
+        public string Title {  get; set; } = string.Empty;
+        public string Url { get; set; } = string.Empty;
+        public bool OpenInNewTab { get; set; }
+        public bool Enabled { get; set; } 
+        public int SortOrder { get; set; }
+        public NavigationMenuItem? ParentItem { get; set; }
+    }
+}

--- a/src/SFA.DAS.TeachInFurtherEducation.Contentful/Options/ContentfulNavigationCacheOptions.cs
+++ b/src/SFA.DAS.TeachInFurtherEducation.Contentful/Options/ContentfulNavigationCacheOptions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.TeachInFurtherEducation.Contentful.Options
+{
+    [ExcludeFromCodeCoverage]
+    public sealed class ContentfulNavigationCacheOptions
+    {
+        public required int HeaderMenuCacheTTLMinutes { get; set; }
+    }
+}

--- a/src/SFA.DAS.TeachInFurtherEducation.Contentful/Services/Interfaces/IContentfulNavigationService.cs
+++ b/src/SFA.DAS.TeachInFurtherEducation.Contentful/Services/Interfaces/IContentfulNavigationService.cs
@@ -1,0 +1,17 @@
+﻿using SFA.DAS.TeachInFurtherEducation.Contentful.Model.Content.Navigation;
+using SFA.DAS.TeachInFurtherEducation.Web.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.TeachInFurtherEducation.Contentful.Services.Interfaces
+{
+    public interface IContentfulNavigationService
+    {
+        Task<NavigationMenuTree?> GetMenuTreeByTitleAsync(string navigationMenuTitle, CancellationToken ct =  default);
+        Task<NavigationMenuTree?> GetPreviewMenuTreeByTitleAsync(string navigationMenuTitle, CancellationToken ct = default);
+    }
+}

--- a/src/SFA.DAS.TeachInFurtherEducation.Contentful/Services/Interfaces/INavigationTreeBuilder.cs
+++ b/src/SFA.DAS.TeachInFurtherEducation.Contentful/Services/Interfaces/INavigationTreeBuilder.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SFA.DAS.TeachInFurtherEducation.Contentful.Model.Content.Navigation;
+using SFA.DAS.TeachInFurtherEducation.Contentful.Services.Navigation;
+using SFA.DAS.TeachInFurtherEducation.Web.Models;
+
+namespace SFA.DAS.TeachInFurtherEducation.Contentful.Services.Interfaces
+{
+    internal interface INavigationTreeBuilder
+    {
+        IReadOnlyList<NavigationMenuTreeItem> BuildNavigationTree(IReadOnlyList<NavigationMenuItem> items);
+    }
+}

--- a/src/SFA.DAS.TeachInFurtherEducation.Contentful/Services/Navigation/ContentfulNavigationService.cs
+++ b/src/SFA.DAS.TeachInFurtherEducation.Contentful/Services/Navigation/ContentfulNavigationService.cs
@@ -1,0 +1,149 @@
+﻿using Contentful.Core;
+using Contentful.Core.Search;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SFA.DAS.TeachInFurtherEducation.Contentful.Exceptions;
+using SFA.DAS.TeachInFurtherEducation.Contentful.Model.Content.Navigation;
+using SFA.DAS.TeachInFurtherEducation.Contentful.Options;
+using SFA.DAS.TeachInFurtherEducation.Contentful.Services.Interfaces;
+using SFA.DAS.TeachInFurtherEducation.Web.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.TeachInFurtherEducation.Contentful.Services.Navigation
+{
+    internal sealed class ContentfulNavigationService : IContentfulNavigationService
+    {
+        private readonly ContentfulNavigationCacheOptions _cacheOptions;
+        private readonly IContentfulClient? _client;
+        private readonly IContentfulClient? _previewClient;
+        private readonly INavigationTreeBuilder _treeBuilder;
+        private readonly IDistributedCache _cache;
+        private readonly ILogger<ContentfulNavigationService> _logger;
+
+        private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+        public ContentfulNavigationService(
+            IOptions<ContentfulNavigationCacheOptions> cacheOptions,
+            IContentfulClientFactory client,
+            INavigationTreeBuilder treeBuilder,
+            IDistributedCache cache,
+            ILogger<ContentfulNavigationService> logger)
+        {
+            _cacheOptions = cacheOptions.Value;
+            _client = client.ContentfulClient;
+            _previewClient = client.PreviewContentfulClient;
+            _treeBuilder = treeBuilder;
+            _cache = cache;
+            _logger = logger;
+        }
+
+        public async Task<NavigationMenuTree?> GetMenuTreeByTitleAsync(string navigationMenuTitle, CancellationToken ct = default)
+        {
+
+            var navigationCacheKey = $"navigation:{navigationMenuTitle}";
+
+            var cachedNavigation = await TryGetNavigationFromCacheAsync(navigationCacheKey, ct);
+            if (cachedNavigation is not null)
+                return cachedNavigation;
+
+            if (_client is null)
+                throw new ContentServiceException("Can't update content without a ContentfulClient.");
+             
+
+            var navigationMenu = await FetchMenuByTitleAsync(_client, navigationMenuTitle, ct);
+            if (navigationMenu is null)
+                return null;
+
+            var result = BuildNavigationMenuTree(navigationMenuTitle, navigationMenu);
+
+            await TrySetCacheWithNavigationAsync(navigationCacheKey, result, ct);
+
+            return result;
+        }
+        private async Task<NavigationMenuTree?> TryGetNavigationFromCacheAsync(string cacheKey, CancellationToken ct = default)
+        {
+            try
+            {
+                var cachedJson = await _cache.GetStringAsync(cacheKey, ct);
+                if (cachedJson is null)
+                    return null;
+
+                return JsonSerializer.Deserialize<NavigationMenuTree>(cachedJson, JsonOptions);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Navigation cache read failed for key {CacheKey}", cacheKey);
+                return null;
+            }
+        }
+
+        private async Task<NavigationMenu?> FetchMenuByTitleAsync(IContentfulClient client, string menuTitle, CancellationToken ct)
+        {
+            var qb = QueryBuilder<NavigationMenu>.New
+                .ContentTypeIs("navigationMenu")
+                .FieldEquals("fields.title", menuTitle)
+                .Include(10)
+                .Limit(1);
+
+            var result = await client.GetEntries(qb, ct);
+            return result.Items.FirstOrDefault();
+        }
+
+        private NavigationMenuTree BuildNavigationMenuTree(string menuTitle, NavigationMenu menu)
+        {
+            var menuTree = _treeBuilder.BuildNavigationTree(menu.MenuItems);
+
+            return new NavigationMenuTree
+            {
+                MenuTitle = menuTitle,
+                Items = menuTree
+            };
+        }
+
+        private async Task TrySetCacheWithNavigationAsync(string cacheKey, NavigationMenuTree value, CancellationToken ct = default)
+        {
+            TimeSpan navigationMenuCacheTTL = TimeSpan.FromMinutes(_cacheOptions.HeaderMenuCacheTTLMinutes);
+
+            try
+            {
+                var json = JsonSerializer.Serialize(value, JsonOptions);
+
+                await _cache.SetStringAsync(
+                    cacheKey,
+                    json,
+                    new DistributedCacheEntryOptions
+                    {
+                        AbsoluteExpirationRelativeToNow = navigationMenuCacheTTL
+                    },
+                    ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Navigation cache write failed for key: {CacheKey}", cacheKey);
+            }
+        }
+
+        public async Task<NavigationMenuTree?> GetPreviewMenuTreeByTitleAsync(string navigationMenuTitle, CancellationToken ct = default)
+        {
+            if (_previewClient is null)
+                throw new ContentServiceException("Can't update preview content without a PreviewContentfulClient.");
+
+            var navigationMenu = await FetchMenuByTitleAsync(_previewClient, navigationMenuTitle, ct);
+            if (navigationMenu is null)
+                return null;
+
+            var result = BuildNavigationMenuTree(navigationMenuTitle, navigationMenu);
+
+            return result;
+        }
+    }
+}

--- a/src/SFA.DAS.TeachInFurtherEducation.Contentful/Services/Navigation/NavigationTreeBuilder.cs
+++ b/src/SFA.DAS.TeachInFurtherEducation.Contentful/Services/Navigation/NavigationTreeBuilder.cs
@@ -1,0 +1,147 @@
+﻿using Microsoft.AspNetCore.Mvc.Razor.Internal;
+using SFA.DAS.TeachInFurtherEducation.Contentful.Model.Content.Navigation;
+using SFA.DAS.TeachInFurtherEducation.Contentful.Services.Interfaces;
+using SFA.DAS.TeachInFurtherEducation.Web.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Metadata.Ecma335;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.TeachInFurtherEducation.Contentful.Services.Navigation
+{
+    internal sealed class NavigationTreeBuilder : INavigationTreeBuilder
+    {
+        public IReadOnlyList<NavigationMenuTreeItem> BuildNavigationTree(IReadOnlyList<NavigationMenuItem> items)
+        {
+            var validItems = items
+                .Where(item => !string.IsNullOrWhiteSpace(item.Sys?.Id))
+                .ToList();
+
+            var menuItemsbyId = CreateMenuItemsById(validItems);
+            var topLevelItems = AttachChildrenToParents(validItems, menuItemsbyId);
+
+            RemoveDisabledItems(topLevelItems);
+            SortMenuItems(topLevelItems);
+
+            return topLevelItems;
+        }
+
+        private static Dictionary<string, NavigationMenuTreeItem> CreateMenuItemsById(IReadOnlyList<NavigationMenuItem> items)
+        {
+            var menuItemsById = new Dictionary<string, NavigationMenuTreeItem>(StringComparer.Ordinal);
+
+            foreach (var item in items)
+            {
+                var id = item.Sys!.Id;
+
+                menuItemsById.TryAdd(id, new NavigationMenuTreeItem
+                {
+                    Id = id,
+                    Title = item.Title ?? string.Empty,
+                    Url = NormaliseUrl(item.Url),
+                    OpenInNewTab = item.OpenInNewTab,
+                    SortOrder = item.SortOrder,
+                    Enabled = item.Enabled,
+                    Children = new List<NavigationMenuTreeItem>()
+                });
+            }
+
+            return menuItemsById;
+        }
+
+        private static List<NavigationMenuTreeItem> AttachChildrenToParents(
+            IReadOnlyList<NavigationMenuItem> items,
+            IReadOnlyDictionary<string, NavigationMenuTreeItem> menuItemsById)
+        {
+            var topLevelItems = new List<NavigationMenuTreeItem>();
+            var addedTopLevelIds = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var item in items)
+            {
+                var id = item.Sys!.Id;
+                var currentItem = menuItemsById[id];
+                var parentId = item.ParentItem?.Sys?.Id;
+
+                if (TryGetParentItem(parentId, id, menuItemsById, out var parentItem))
+                {
+                    parentItem!.Children.Add(currentItem);
+                    continue;
+                }
+
+                if (addedTopLevelIds.Add(id))
+                    topLevelItems.Add(currentItem);
+            }
+
+            return topLevelItems;
+        }
+
+        private static bool TryGetParentItem(
+            string? parentId,
+            string currentItemId,
+            IReadOnlyDictionary<string, NavigationMenuTreeItem> menuItemsById,
+            out NavigationMenuTreeItem? parentItem)
+        {
+            parentItem = null;
+
+            if (string.IsNullOrWhiteSpace(parentId))
+                return false;
+
+            if (string.Equals(parentId, currentItemId, StringComparison.Ordinal))
+                return false;
+
+            return menuItemsById.TryGetValue(parentId, out parentItem);
+        }
+
+        private static void RemoveDisabledItems(List<NavigationMenuTreeItem> items)
+        {
+            for (var i = items.Count - 1; i >= 0; i--)
+            {
+                var item = items[i];
+
+                if (!item.Enabled)
+                {
+                    items.RemoveAt(i);
+                    continue;
+                }
+
+                if (item.Children.Count > 0)
+                    RemoveDisabledItems(item.Children);
+            }
+        }
+
+        private static void SortMenuItems(List<NavigationMenuTreeItem> items)
+        {
+            items.Sort(CompareMenuItems);
+
+            for (var i = 0; i < items.Count; i++)
+            {
+                if (items[i].Children.Count > 0)
+                    SortMenuItems(items[i].Children);
+            }
+        }
+
+        private static int CompareMenuItems(NavigationMenuTreeItem a,  NavigationMenuTreeItem b)
+        {
+            var sortOrderComparison = a.SortOrder.CompareTo(b.SortOrder);
+
+            return sortOrderComparison != 0
+                ? sortOrderComparison
+                : string.Compare(a.Title, b.Title, StringComparison.OrdinalIgnoreCase);
+        }
+                                                                                                                             
+        private static string NormaliseUrl(string? url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+                return "/";
+
+            if (Uri.TryCreate(url, UriKind.Absolute, out _))
+                return url;
+
+            return url.StartsWith('/') ? url : "/" + url;
+        }
+
+    }
+}

--- a/src/SFA.DAS.TeachInFurtherEducation.Web/SFA.DAS.TeachInFurtherEducation.Web.csproj
+++ b/src/SFA.DAS.TeachInFurtherEducation.Web/SFA.DAS.TeachInFurtherEducation.Web.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.5" />
     <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.21.0" />
     <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders.TagHelpers" Version="0.21.0" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.84" />

--- a/src/SFA.DAS.TeachInFurtherEducation.Web/Services/ContentfulNavigationOptions.cs
+++ b/src/SFA.DAS.TeachInFurtherEducation.Web/Services/ContentfulNavigationOptions.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Identity.Client;
+using System.Diagnostics.CodeAnalysis;
+
+namespace SFA.DAS.TeachInFurtherEducation.Web.Services
+{
+    [ExcludeFromCodeCoverage]
+    public sealed class ContentfulNavigationOptions
+    {
+        public required bool Enabled { get; set; }
+        public required string HeaderMenuTitle { get; set; }
+        public required int HeaderMenuCacheTTLMinutes { get; set; }
+    }
+}

--- a/src/SFA.DAS.TeachInFurtherEducation.Web/Services/Interfaces/INavigationMenuProvider.cs
+++ b/src/SFA.DAS.TeachInFurtherEducation.Web/Services/Interfaces/INavigationMenuProvider.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.Primitives;
+using SFA.DAS.TeachInFurtherEducation.Web.Models;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.TeachInFurtherEducation.Web.Services.Interfaces
+{
+    internal interface INavigationMenuProvider
+    {
+        Task<IReadOnlyList<NavigationMenuTreeItem>> GetHeaderMenuItemsAsync(CancellationToken ct = default);
+    }
+}

--- a/src/SFA.DAS.TeachInFurtherEducation.Web/Services/NavigationMenuProvider.cs
+++ b/src/SFA.DAS.TeachInFurtherEducation.Web/Services/NavigationMenuProvider.cs
@@ -1,0 +1,112 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SFA.DAS.TeachInFurtherEducation.Contentful.Services.Interfaces;
+using SFA.DAS.TeachInFurtherEducation.Web.Models;
+using SFA.DAS.TeachInFurtherEducation.Web.Services.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.TeachInFurtherEducation.Web.Services
+{
+    internal sealed class NavigationMenuProvider : INavigationMenuProvider
+    {
+        private readonly ContentfulNavigationOptions _options;
+        private readonly IContentfulNavigationService _contentfulNav;
+        private readonly DropdownMenuService _legacyNav;
+        private readonly ILogger<NavigationMenuProvider> _logger;
+        private readonly IHttpContextAccessor _http;
+
+        public NavigationMenuProvider(
+            IOptions<ContentfulNavigationOptions> options,
+            IContentfulNavigationService contentfulNav,
+            DropdownMenuService legacyNav,
+            ILogger<NavigationMenuProvider> logger,
+            IHttpContextAccessor http
+            )
+        {
+            _options = options.Value;
+            _contentfulNav = contentfulNav;
+            _legacyNav = legacyNav;
+            _logger = logger;
+            _http = http;
+        }
+
+        public async Task<IReadOnlyList<NavigationMenuTreeItem>> GetHeaderMenuItemsAsync(CancellationToken ct = default)
+        {
+            if (!_options.Enabled)
+                return GetLegacyMenuItems();
+
+            if (string.IsNullOrWhiteSpace(_options.HeaderMenuTitle))
+            {
+                _logger.LogWarning("Navigation Header Menu Title is not configured. Falling back.");
+                return GetLegacyMenuItems();
+            }
+
+            try
+            {
+                var menu = await GetContentfulMenuAsync(_options.HeaderMenuTitle, ct);
+
+                if (menu?.Items is { Count: > 0 })
+                    return menu.Items;
+
+                _logger.LogWarning("Contentful navigation returned empty menu for {NavigationHeaderMenuTitle}. Falling back.", _options.HeaderMenuTitle);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Conetntful navigation failed for {NavigationHeaderMenuTitle}", _options.HeaderMenuTitle);
+            }
+
+            return GetLegacyMenuItems();
+        }
+
+        private async Task<NavigationMenuTree?> GetContentfulMenuAsync(string title, CancellationToken ct)
+        {
+            return IsPreviewRequest()
+                ? await _contentfulNav.GetPreviewMenuTreeByTitleAsync(title, ct)
+                : await _contentfulNav.GetMenuTreeByTitleAsync(title, ct);
+        }
+
+        private bool IsPreviewRequest()
+        {
+            var path = _http.HttpContext?.Request?.Path.Value;
+            return path?.StartsWith("/preview", StringComparison.OrdinalIgnoreCase) == true;
+        }
+
+        private IReadOnlyList<NavigationMenuTreeItem> GetLegacyMenuItems()
+        {
+            var legacyItems = _legacyNav.GetDropdownMenuItems();
+            if (legacyItems is not { Count: > 0 })
+            {
+                _logger.LogWarning("Legacy menu source returned no items.");
+                return Array.Empty<NavigationMenuTreeItem>();
+            }
+
+            return legacyItems.Select(MapLegacy).ToList();
+        }
+
+        private static NavigationMenuTreeItem MapLegacy(DropdownMenuItem item)
+        {
+            return new NavigationMenuTreeItem
+            {
+                Id = CreateLegacyMenuItemId(item),
+                Title = item.Title ?? string.Empty,
+                Url = item.Url ?? string.Empty,
+                OpenInNewTab = false,
+                SortOrder = 0,
+                Children = item.Children?.Select(MapLegacy).ToList() ?? []
+            };
+        }
+        
+        private static string CreateLegacyMenuItemId(DropdownMenuItem item)
+        {
+            var source = item.Title ?? item.Url ?? "item";
+            return source.Trim().Replace(" ", "", StringComparison.Ordinal);
+        }
+    }
+}

--- a/src/SFA.DAS.TeachInFurtherEducation.Web/Startup.cs
+++ b/src/SFA.DAS.TeachInFurtherEducation.Web/Startup.cs
@@ -32,6 +32,7 @@ using SFA.DAS.TeachInFurtherEducation.Web.StartupServices;
 using System.Diagnostics.CodeAnalysis;
 using System;
 using SFA.DAS.TeachInFurtherEducation.Web.Configuration;
+using SFA.DAS.TeachInFurtherEducation.Contentful.Options;
 
 namespace SFA.DAS.TeachInFurtherEducation.Web
 {
@@ -216,6 +217,17 @@ namespace SFA.DAS.TeachInFurtherEducation.Web
             services.AddTransient<ISitemap, Sitemap>()
                 .AddHostedService<SitemapGeneratorService>();
 
+            // Register Contentful Navigtion service
+            services.Configure<ContentfulNavigationOptions>(Configuration.GetSection("ContentfulNavigationOptions"));
+            services.Configure<ContentfulNavigationCacheOptions>(Configuration.GetSection("ContentfulNavigationOptions"));
+            services.AddScoped<INavigationMenuProvider, NavigationMenuProvider>();
+
+            // Register Redis
+            services.AddStackExchangeRedisCache(options =>
+            {
+                options.Configuration = Configuration.GetConnectionString("Redis");
+                options.InstanceName = "TeachInFurtherEducation";
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/SFA.DAS.TeachInFurtherEducation.Web/Views/Shared/_LayoutMenuPartial.cshtml
+++ b/src/SFA.DAS.TeachInFurtherEducation.Web/Views/Shared/_LayoutMenuPartial.cshtml
@@ -1,10 +1,12 @@
 ﻿@using Microsoft.Extensions.Configuration
 @inject IConfiguration Configuration
 @using SFA.DAS.TeachInFurtherEducation.Contentful.Model.Interim
+@using SFA.DAS.TeachInFurtherEducation.Contentful.Services.Interfaces
 @using SFA.DAS.TeachInFurtherEducation.Web.Infrastructure
 @using SFA.DAS.TeachInFurtherEducation.Web.Services
-@inject DropdownMenuService DropdownMenuService
-
+@using SFA.DAS.TeachInFurtherEducation.Contentful.Services
+@using SFA.DAS.TeachInFurtherEducation.Web.Services.Interfaces
+@inject INavigationMenuProvider NavigationMenuProvider
 
 @addTagHelper *, NetEscapades.AspNetCore.SecurityHeaders.TagHelpers
 
@@ -67,34 +69,34 @@
 
                 <div id="navbarNavDropdown">
                     <ul class="navbar__nav">
-                        @{
-                            var dropdownMenuItems = DropdownMenuService.GetDropdownMenuItems();
-                            var currentPath = Context.Request.Path.ToString();
+                    @{
+                        IReadOnlyList<NavigationMenuTreeItem> dropdownMenuItems = await NavigationMenuProvider.GetHeaderMenuItemsAsync();
+                        var currentPath = Context.Request.Path.ToString();
 
-                            // Recursive function to check if any child (at any depth) is active
-                            bool IsAnyChildActive(DropdownMenuItem menuItem)
+                        // Recursive function to check if any child (at any depth) is active
+                        bool IsAnyChildActive(NavigationMenuTreeItem menuItem)
+                        {
+                            if (currentPath.Equals(menuItem.Url, StringComparison.OrdinalIgnoreCase))
+                                return true;
+
+                            if (menuItem.Children.Count > 0)
                             {
-                                if (currentPath.Equals(menuItem.Url, StringComparison.OrdinalIgnoreCase))
-                                    return true;
-
-                                if (menuItem.HasChildren)
+                                foreach (var child in menuItem.Children)
                                 {
-                                    foreach (var child in menuItem.Children)
-                                    {
-                                        if (IsAnyChildActive(child))
-                                            return true;
-                                    }
+                                    if (IsAnyChildActive(child))
+                                        return true;
                                 }
-
-                                return false;
                             }
 
-                            // Recursive function to render menu items at any depth
-                            void RenderMenuItem(DropdownMenuItem menuItem, int level)
-                            {
-                                var isActive = currentPath.Equals(menuItem.Url, StringComparison.OrdinalIgnoreCase);
-                                var hasChildren = menuItem.HasChildren;
-                                var isParentActive = hasChildren && IsAnyChildActive(menuItem);
+                            return false;
+                        }
+
+                        // Recursive function to render menu items at any depth
+                        void RenderMenuItem(NavigationMenuTreeItem menuItem, int level)
+                        {
+                            var isActive = currentPath.Equals(menuItem.Url, StringComparison.OrdinalIgnoreCase);
+                            var hasChildren = menuItem.Children.Count > 0;
+                            var isParentActive = hasChildren && IsAnyChildActive(menuItem);
 
                                 if (level == 0)
                                 {
@@ -121,7 +123,11 @@
                                         else
                                         {
                                             <a class="navbar__link @(isActive ? "navbar__link--active" : "")"
-                                               href="@menuItem.Url">@menuItem.Title</a>
+                                               href="@menuItem.Url"
+                                               target="@(menuItem.OpenInNewTab ? "_blank" : null)"
+                                               rel="@(menuItem.OpenInNewTab ? "noopener noreferrer" : null)">
+                                               @menuItem.Title
+                                            </a>
                                         }
                                     </li>
                                 }
@@ -147,7 +153,11 @@
                                     {
                                         <li class="navbar__dropdown-item">
                                             <a class="navbar__dropdown-link @(isActive ? "navbar__dropdown-link--active" : "")"
-                                               href="@menuItem.Url">@menuItem.Title</a>
+                                               href="@menuItem.Url"
+                                               target="@(menuItem.OpenInNewTab ? "_blank" : null)"
+                                               rel="@(menuItem.OpenInNewTab ? "noopener noreferrer" : null)">
+                                               @menuItem.Title
+                                            </a>
                                         </li>
                                     }
                                 }
@@ -173,7 +183,11 @@
                                     {
                                         <li class="navbar__dropdown-submenu-item">
                                             <a class="navbar__dropdown-submenu-link @(isActive ? "navbar__dropdown-submenu-link--active" : "")"
-                                               href="@menuItem.Url">@menuItem.Title</a>
+                                               href="@menuItem.Url"
+                                               target="@(menuItem.OpenInNewTab ? "_blank" : null)"
+                                               rel="@(menuItem.OpenInNewTab ? "noopener noreferrer" : null)">
+                                               @menuItem.Title
+                                            </a>
                                         </li>
                                     }
                                 }

--- a/src/SFA.DAS.TeachInFurtherEducation.Web/appsettings.json
+++ b/src/SFA.DAS.TeachInFurtherEducation.Web/appsettings.json
@@ -47,6 +47,11 @@
     "MaxNumberOfRateLimitRetries": 0,
     "Environment": "at"
   },
+  "ContentfulNavigationOptions": {
+    "Enabled": true,
+    "HeaderMenuTitle": "NavigationMenu",
+    "HeaderMenuCacheTTLMinutes": 60
+  },
   "GoogleAnalytics": {
     "GoogleTagManagerId": ""
   },


### PR DESCRIPTION
This PR replaces the hard-coded header navigation with a Contentful dynamic navigation mode. Navigation is fetched from Contentful, transformed into a hierarchical tree, cached via Redis, and rendered in the existing layout. A feature flag and legacy fallback mechanism is included for a safe rollout.
